### PR TITLE
ignore設定とsecurity設定解除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ out/
 *.class
 
 # Log file
-*.log
+*.log*
 
 # Package Files #
 *.jar

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.1'


### PR DESCRIPTION
.logのあとに接尾辞がある場合に対応
securityの設定をbuild.gradleに書いておくとデフォルトで認証ページに飛んでしまうので削除した．